### PR TITLE
bugfix: disallow multiple auth headers

### DIFF
--- a/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationService.java
+++ b/extensions/common/auth/auth-tokenbased/src/main/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationService.java
@@ -50,6 +50,6 @@ public class TokenBasedAuthenticationService implements AuthenticationService {
     }
 
     private boolean checkApiKeyValid(List<String> apiKeys) {
-        return apiKeys.stream().anyMatch(hardCodedApiKey::equalsIgnoreCase);
+        return apiKeys.size() == 1 && apiKeys.stream().allMatch(hardCodedApiKey::equalsIgnoreCase);
     }
 }

--- a/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
+++ b/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
@@ -69,8 +69,8 @@ class TokenBasedAuthenticationServiceTest {
     }
 
     @Test
-    void isAuthorized_multipleValues_oneAuthorized() {
+    void isAuthorized_multipleValues_oneAuthorized_shouldReturnFalse(){
         var map = Map.of("x-api-key", List.of("invalid_api_key", TEST_API_KEY));
-        assertThat(service.isAuthenticated(map)).isTrue();
+        assertThat(service.isAuthenticated(map)).isFalse();
     }
 }


### PR DESCRIPTION
# What this PR changes/adds
_Disallows the use of multiple x-api-key headers._

Original PR: https://github.com/eclipse-edc/Connector/pull/3607