### PR TITLE
bugfix: disable jetty server version

### DIFF
--- a/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
+++ b/extensions/common/http/jetty-core/src/main/java/org/eclipse/edc/web/jetty/JettyService.java
@@ -203,6 +203,7 @@ public class JettyService implements WebServer {
     @NotNull
     private HttpConnectionFactory httpConnectionFactory() {
         HttpConfiguration https = new HttpConfiguration();
+        https.setSendServerVersion(false);
         return new HttpConnectionFactory(https);
     }
 


### PR DESCRIPTION
# What this PR changes/adds
_In the JettyService class the Jetty server version via the HttpConfiguration now is disabled._

# Why it does that
_This issue can lead to a potential attacker finding a vulnerability in Jetty more quickly._

Original PR: https://github.com/eclipse-edc/Connector/pull/3542