### PR TITLE
fix: thrown excp and logs that would wrongly refer to ContractDefinit…

### DIFF
--- a/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
+++ b/extensions/common/auth/auth-tokenbased/src/test/java/org/eclipse/edc/api/auth/token/TokenBasedAuthenticationServiceTest.java
@@ -69,7 +69,7 @@ class TokenBasedAuthenticationServiceTest {
     }
 
     @Test
-    void isAuthorized_multipleValues_oneAuthorized_shouldReturnFalse(){
+    void isAuthorized_multipleValues_oneAuthorized_shouldReturnFalse() {
         var map = Map.of("x-api-key", List.of("invalid_api_key", TEST_API_KEY));
         assertThat(service.isAuthenticated(map)).isFalse();
     }

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -90,7 +90,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
                 .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
     }
 
     @GET
@@ -101,7 +101,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
         return Optional.of(id)
                 .map(service::getState)
                 .map(NegotiationState::new)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, id));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, id));
     }
 
     @GET
@@ -115,7 +115,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
                 .map(it -> transformerRegistry.transform(it, ContractAgreementDto.class))
                 .filter(Result::succeeded)
                 .map(Result::getContent)
-                .orElseThrow(() -> new ObjectNotFoundException(ContractDefinition.class, negotiationId));
+                .orElseThrow(() -> new ObjectNotFoundException(ContractNegotiation.class, negotiationId));
     }
 
     @POST
@@ -139,7 +139,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @Path("/{id}/cancel")
     @Override
     public void cancelNegotiation(@PathParam("id") String id) {
-        monitor.debug(format("Attempting to cancel contract definition with id %s", id));
+        monitor.debug(format("Attempting to cancel contract negotiation with id %s", id));
         var result = service.cancel(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
         monitor.debug(format("Contract negotiation canceled %s", result.getId()));
     }
@@ -148,7 +148,7 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
     @Path("/{id}/decline")
     @Override
     public void declineNegotiation(@PathParam("id") String id) {
-        monitor.debug(format("Attempting to decline contract definition with id %s", id));
+        monitor.debug(format("Attempting to decline contract negotiation with id %s", id));
         var result = service.decline(id).orElseThrow(exceptionMapper(ContractNegotiation.class, id));
         monitor.debug(format("Contract negotiation declined %s", result.getId()));
     }
@@ -161,9 +161,9 @@ public class ContractNegotiationApiController implements ContractNegotiationApi 
 
         var spec = result.getContent();
 
-        monitor.debug(format("Get all contract definitions %s", spec));
+        monitor.debug(format("Get all contract negotiations %s", spec));
 
-        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractDefinition.class, null))) {
+        try (var stream = service.query(spec).orElseThrow(exceptionMapper(ContractNegotiation.class, null))) {
             return stream
                     .map(it -> transformerRegistry.transform(it, ContractNegotiationDto.class))
                     .filter(Result::succeeded)

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/main/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiController.java
@@ -34,7 +34,6 @@ import org.eclipse.edc.connector.api.management.contractnegotiation.model.Negoti
 import org.eclipse.edc.connector.api.management.contractnegotiation.model.NegotiationState;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractNegotiation;
 import org.eclipse.edc.connector.contract.spi.types.negotiation.ContractOfferRequest;
-import org.eclipse.edc.connector.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.spi.contractnegotiation.ContractNegotiationService;
 import org.eclipse.edc.spi.monitor.Monitor;
 import org.eclipse.edc.spi.query.QuerySpec;

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -144,8 +144,7 @@ class ContractNegotiationApiControllerTest {
         assertThatThrownBy(() -> controller.getNegotiation("nonExistingId"))
                 .isInstanceOf(ObjectNotFoundException.class)
                 .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
-
-         }
+    }
 
     @Test
     void getContractNegotiationState_found() {
@@ -163,7 +162,7 @@ class ContractNegotiationApiControllerTest {
         assertThatThrownBy(() -> controller.getNegotiationState("nonExistingId"))
                 .isInstanceOf(ObjectNotFoundException.class)
                 .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
-        }
+    }
 
     @Test
     void getAgreementForNegotiation() {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -128,7 +128,10 @@ class ContractNegotiationApiControllerTest {
     void getContractNegotiation_notFound() {
         when(service.findbyId("negotiationId")).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
+
         verifyNoInteractions(transformerRegistry);
     }
 
@@ -138,8 +141,11 @@ class ContractNegotiationApiControllerTest {
         when(service.findbyId("negotiationId")).thenReturn(contractNegotiation);
         when(transformerRegistry.transform(isA(ContractNegotiation.class), eq(ContractNegotiationDto.class))).thenReturn(Result.failure("failure"));
 
-        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
-    }
+        assertThatThrownBy(() -> controller.getNegotiation("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
+
+         }
 
     @Test
     void getContractNegotiationState_found() {
@@ -154,8 +160,10 @@ class ContractNegotiationApiControllerTest {
     void getContractNegotiationState_notFound() {
         when(service.getState("negotiationId")).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getNegotiationState("nonExistingId")).isInstanceOf(ObjectNotFoundException.class);
-    }
+        assertThatThrownBy(() -> controller.getNegotiationState("nonExistingId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=nonExistingId was not found");
+        }
 
     @Test
     void getAgreementForNegotiation() {
@@ -174,7 +182,9 @@ class ContractNegotiationApiControllerTest {
     void getAgreementForNegotiation_negotiationNotExist() {
         when(service.getForNegotiation(any())).thenReturn(null);
 
-        assertThatThrownBy(() -> controller.getAgreementForNegotiation("negotiationId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.getAgreementForNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
         verifyNoInteractions(transformerRegistry);
     }
 
@@ -257,7 +267,9 @@ class ContractNegotiationApiControllerTest {
     void decline_notPossible() {
         when(service.decline("negotiationId")).thenReturn(ServiceResult.conflict("conflict"));
 
-        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId")).isInstanceOf(ObjectConflictException.class);
+        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# What this PR changes/adds
- Fixes API resource class references in logs and exceptions thrown in ContractNegotiationApiController.
- Adds test assertions for the thrown exception messages' content.
# Why it does that
- Previously it would wrongly refer to ContractDefinition instead of ContracNegotiation.



Original Pr: https://github.com/eclipse-edc/Connector/pull/2696