### PR TITLE
feat: permit to configure fs vault with configuration file

### DIFF
--- a/core/common/util/src/main/java/org/eclipse/edc/util/configuration/ConfigurationFunctions.java
+++ b/core/common/util/src/main/java/org/eclipse/edc/util/configuration/ConfigurationFunctions.java
@@ -26,11 +26,11 @@ public class ConfigurationFunctions {
      * <p>Naming conventions for keys are '[qualifier].[value]' in lower case. When checking for env variables, keys will be converted to uppercase and '.' replaced by '_'.</p>
      */
     public static String propOrEnv(String key, String defaultValue) {
-        String value = System.getProperty(key);
+        var value = System.getProperty(key);
         if (!StringUtils.isNullOrBlank(value)) {
             return value;
         }
-        String upperKey = key.toUpperCase().replace('.', '_');
+        var upperKey = key.toUpperCase().replace('.', '_');
         value = System.getenv(upperKey);
         if (!StringUtils.isNullOrBlank(value)) {
             return value;

--- a/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
+++ b/core/common/util/src/test/java/org/eclipse/edc/util/configuration/ConfigurationFunctionsTest.java
@@ -56,7 +56,7 @@ class ConfigurationFunctionsTest {
     @SetSystemProperty(key = SYS_PROP_2, value = "")
     @SetSystemProperty(key = SYS_PROP_3, value = "    ")
     public void returnSystemProperty(String key, String expected) {
-        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        var resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
     }
 
@@ -66,13 +66,13 @@ class ConfigurationFunctionsTest {
     @SetEnvironmentVariable(key = EDC_VAR_3, value = "    ")
     @MethodSource("envVarsSource")
     public void returnEnv(String key, String expected) {
-        String resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
+        var resultValue = ConfigurationFunctions.propOrEnv(key, DEFAULT);
         assertThat(resultValue).isEqualTo(expected);
     }
 
     @Test
     public void returnDefaultEnv_NullValue() {
-        String resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
+        var resultValue = ConfigurationFunctions.propOrEnv("nonexistent", DEFAULT);
         assertThat(resultValue).isEqualTo(DEFAULT);
     }
 

--- a/extensions/common/vault/vault-filesystem/src/main/java/org/eclipse/edc/vault/filesystem/FsVaultExtension.java
+++ b/extensions/common/vault/vault-filesystem/src/main/java/org/eclipse/edc/vault/filesystem/FsVaultExtension.java
@@ -16,6 +16,7 @@ package org.eclipse.edc.vault.filesystem;
 
 import org.eclipse.edc.runtime.metamodel.annotation.BaseExtension;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.security.CertificateResolver;
@@ -25,13 +26,11 @@ import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 
-import static org.eclipse.edc.util.configuration.ConfigurationFunctions.propOrEnv;
 import static org.eclipse.edc.vault.filesystem.FsConfiguration.KEYSTORE_LOCATION;
 import static org.eclipse.edc.vault.filesystem.FsConfiguration.KEYSTORE_PASSWORD;
 import static org.eclipse.edc.vault.filesystem.FsConfiguration.PERSISTENT_VAULT;
@@ -41,7 +40,7 @@ import static org.eclipse.edc.vault.filesystem.FsConfiguration.VAULT_LOCATION;
  * Bootstraps the file system-based vault extension.
  */
 @BaseExtension
-@Provides({ Vault.class, PrivateKeyResolver.class, CertificateResolver.class })
+@Provides({ PrivateKeyResolver.class, CertificateResolver.class })
 @Extension(value = FsVaultExtension.NAME)
 public class FsVaultExtension implements ServiceExtension {
 
@@ -54,11 +53,9 @@ public class FsVaultExtension implements ServiceExtension {
 
     @Override
     public void initialize(ServiceExtensionContext context) {
-        var vault = initializeVault();
-        context.registerService(Vault.class, vault);
+        var keyStore = loadKeyStore(context);
+        var keystorePassword = context.getSetting(KEYSTORE_PASSWORD, null);
 
-        KeyStore keyStore = loadKeyStore();
-        var keystorePassword = propOrEnv(KEYSTORE_PASSWORD, null);
         var privateKeyResolver = new FsPrivateKeyResolver(keystorePassword, keyStore);
         context.registerService(PrivateKeyResolver.class, privateKeyResolver);
 
@@ -66,30 +63,31 @@ public class FsVaultExtension implements ServiceExtension {
         context.registerService(CertificateResolver.class, certificateResolver);
     }
 
-    private Vault initializeVault() {
-        var vaultLocation = propOrEnv(VAULT_LOCATION, "dataspaceconnector-vault.properties");
+    @Provider
+    public Vault vault(ServiceExtensionContext context) {
+        var vaultLocation = context.getSetting(VAULT_LOCATION, "dataspaceconnector-vault.properties");
         var vaultPath = Paths.get(vaultLocation);
         if (!Files.exists(vaultPath)) {
             throw new EdcException("Vault file does not exist: " + vaultLocation);
         }
-        var persistentVault = Boolean.parseBoolean(propOrEnv(PERSISTENT_VAULT, "true"));
+        var persistentVault = context.getSetting(PERSISTENT_VAULT, true);
         return new FsVault(vaultPath, persistentVault);
     }
 
-    private KeyStore loadKeyStore() {
-        var keyStoreLocation = propOrEnv(KEYSTORE_LOCATION, "dataspaceconnector-keystore.jks");
+    private KeyStore loadKeyStore(ServiceExtensionContext context) {
+        var keyStoreLocation = context.getSetting(KEYSTORE_LOCATION, "dataspaceconnector-keystore.jks");
         var keyStorePath = Paths.get(keyStoreLocation);
         if (!Files.exists(keyStorePath)) {
             throw new EdcException("Key store does not exist: " + keyStoreLocation);
         }
 
-        var keystorePassword = propOrEnv(KEYSTORE_PASSWORD, null);
+        var keystorePassword = context.getSetting(KEYSTORE_PASSWORD, null);
         if (keystorePassword == null) {
             throw new EdcException("Key store password was not specified");
         }
 
-        try (InputStream stream = Files.newInputStream(keyStorePath)) {
-            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        try (var stream = Files.newInputStream(keyStorePath)) {
+            var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
             keyStore.load(stream, keystorePassword.toCharArray());
             return keyStore;
         } catch (IOException | GeneralSecurityException e) {

--- a/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
+++ b/extensions/control-plane/api/management-api/contract-negotiation-api/src/test/java/org/eclipse/edc/connector/api/management/contractnegotiation/ContractNegotiationApiControllerTest.java
@@ -259,16 +259,16 @@ class ContractNegotiationApiControllerTest {
     void decline_notFound() {
         when(service.decline("negotiationId")).thenReturn(ServiceResult.notFound("not found"));
 
-        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId")).isInstanceOf(ObjectNotFoundException.class);
+        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId"))
+                .isInstanceOf(ObjectNotFoundException.class)
+                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
     }
 
     @Test
     void decline_notPossible() {
         when(service.decline("negotiationId")).thenReturn(ServiceResult.conflict("conflict"));
 
-        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId"))
-                .isInstanceOf(ObjectNotFoundException.class)
-                .hasMessage("Object of type ContractNegotiation with ID=negotiationId was not found");
+        assertThatThrownBy(() -> controller.declineNegotiation("negotiationId")).isInstanceOf(ObjectConflictException.class);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
# What this PR changes/adds
_Uses getSetting where possible instead of propOrEnv_

# Why it does that
_permit vault to be configured via configuration (!)_