### PR TITLE
fix: negotiate contract definition with validity

### DIFF
--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ConsumerContractNegotiationManagerImpl.java
@@ -309,7 +309,7 @@ public class ConsumerContractNegotiationManagerImpl extends AbstractContractNego
         var policy = lastOffer.getPolicy();
         var agreement = ContractAgreement.Builder.newInstance()
                 .id(ContractId.createContractId(definitionId))
-                .contractStartDate(clock.instant().getEpochSecond())
+                .contractStartDate(lastOffer.getContractStart().toInstant().getEpochSecond())
                 .contractEndDate(lastOffer.getContractEnd().toEpochSecond())
                 .contractSigningDate(clock.instant().getEpochSecond())
                 .providerAgentId(String.valueOf(lastOffer.getProvider()))

--- a/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
+++ b/core/control-plane/contract-core/src/main/java/org/eclipse/edc/connector/contract/negotiation/ProviderContractNegotiationManagerImpl.java
@@ -281,7 +281,7 @@ public class ProviderContractNegotiationManagerImpl extends AbstractContractNego
             //TODO move to own service
             agreement = ContractAgreement.Builder.newInstance()
                     .id(ContractId.createContractId(definitionId))
-                    .contractStartDate(clock.instant().getEpochSecond())
+                    .contractStartDate(lastOffer.getContractStart().toEpochSecond())
                     .contractEndDate(lastOffer.getContractEnd().toEpochSecond())
                     .contractSigningDate(clock.instant().getEpochSecond())
                     .providerAgentId(String.valueOf(lastOffer.getProvider()))


### PR DESCRIPTION
# What this PR changes/adds
_Fixes the contract validity failure and the related timing issue._

# Why it does that
_Contract negotiation fails when the validity doesn't match with contract offer definition validity._

Original PR: https://github.com/eclipse-edc/Connector/pull/2679/