### PR TITLE
Adds support for participant identities for Iam Mock

### DIFF
--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/IamMockExtension.java
@@ -15,10 +15,14 @@
 package org.eclipse.edc.iam.mock;
 
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
+import org.eclipse.edc.runtime.metamodel.annotation.Inject;
 import org.eclipse.edc.runtime.metamodel.annotation.Provides;
 import org.eclipse.edc.spi.iam.IdentityService;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.eclipse.edc.spi.system.ServiceExtensionContext;
+import org.eclipse.edc.spi.types.TypeManager;
+
+import java.util.Objects;
 
 /**
  * An IAM provider mock used for testing.
@@ -29,6 +33,9 @@ public class IamMockExtension implements ServiceExtension {
 
     public static final String NAME = "Mock IAM";
 
+    @Inject
+    private TypeManager typeManager;
+
     @Override
     public String name() {
         return NAME;
@@ -37,6 +44,7 @@ public class IamMockExtension implements ServiceExtension {
     @Override
     public void initialize(ServiceExtensionContext context) {
         var region = context.getSetting("edc.mock.region", "eu");
-        context.registerService(IdentityService.class, new MockIdentityService(context.getTypeManager(), region));
+        var idsId = Objects.requireNonNull(context.getSetting("edc.ids.id", null));
+        context.registerService(IdentityService.class, new MockIdentityService(typeManager, region, idsId));
     }
 }

--- a/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
+++ b/extensions/common/iam/iam-mock/src/main/java/org/eclipse/edc/iam/mock/MockIdentityService.java
@@ -31,9 +31,12 @@ public class MockIdentityService implements IdentityService {
     private final String region;
     private final TypeManager typeManager;
 
-    public MockIdentityService(TypeManager typeManager, String region) {
+    private final String clientId;
+
+    public MockIdentityService(TypeManager typeManager, String region, String clientId) {
         this.typeManager = typeManager;
         this.region = region;
+        this.clientId = clientId;
     }
 
     @Override
@@ -41,6 +44,7 @@ public class MockIdentityService implements IdentityService {
         var token = new MockToken();
         token.setAudience(parameters.getAudience());
         token.setRegion(region);
+        token.setClientId(clientId);
         TokenRepresentation tokenRepresentation = TokenRepresentation.Builder.newInstance()
                 .token(typeManager.writeValueAsString(token))
                 .build();
@@ -53,12 +57,16 @@ public class MockIdentityService implements IdentityService {
         if (!Objects.equals(token.audience, audience)) {
             return Result.failure(format("Mismatched audience: expected %s, got %s", audience, token.audience));
         }
-        return Result.success(ClaimToken.Builder.newInstance().claim("region", token.region).build());
+        return Result.success(ClaimToken.Builder.newInstance()
+                .claim("region", token.region)
+                .claim("client_id", token.clientId)
+                .build());
     }
 
     private static class MockToken {
         private String region;
         private String audience;
+        private String clientId;
 
         public String getAudience() {
             return audience;
@@ -75,5 +83,15 @@ public class MockIdentityService implements IdentityService {
         public void setRegion(String region) {
             this.region = region;
         }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public void setClientId(String clientId) {
+            this.clientId = clientId;
+        }
     }
+
+
 }


### PR DESCRIPTION
# What this PR changes/adds
_Adds support for participant identities in IamMock

Original PR: https://github.com/eclipse-edc/Connector/pull/2630